### PR TITLE
Add postgres-crd-controller repository.

### DIFF
--- a/repos-other.tf
+++ b/repos-other.tf
@@ -9,6 +9,18 @@ module "repo_proclaim" {
   }
 }
 
+module "repo_postgres_crd_controller" {
+  source      = "./modules/repo"
+  name        = "postgres-crd-controller"
+  description = "🚧 A Kubernetes controller and CRD that manages PostgreSQL databases."
+  languages   = ["go"]
+  private     = true
+
+  copyright = {
+    since = 2026
+  }
+}
+
 module "repo_dotgithub" {
   source      = "./modules/repo"
   name        = ".github"


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds `postgres-crd-controller` repository.

#### Why make this change?

The repository to be added is required to maintain the code for k8s CRD controller that manages PostgreSQL databases and related k8s resources.

#### Is there anything you are unsure about?

None.

#### What issues does this relate to?

N/A
